### PR TITLE
Fix build with 0.13.0 and add support for zon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 zig-out/
 zig-cache/
 kcov-output/
+.zig-cache/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 This implements `base32` `encoding` and `decoding` for the zig programming language (ziglang)
 
+# Installation 
+First fetch dependency by running:
+```
+zig fetch --save git+https://github.com/gernest/base32
+```
+Then update your `build.zig` file to load the module:
+```
+const base32 = b.dependency("base32", .{});
+exe.root_module.addImport("base32", base32.module("base32"));
+```
+
 # Usage 
 
 `example.zig`

--- a/build.zig
+++ b/build.zig
@@ -1,27 +1,38 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
+pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
     const lib = b.addStaticLibrary(
         .{
             .name = "base32",
-            .root_source_file = .{ .path = "src/base32.zig" },
+            .root_source_file = b.path("src/base32.zig"),
             .target = target,
             .optimize = optimize,
         },
     );
-    lib.install();
+
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
+    b.installArtifact(lib);
+
+    // This adds a module which allows it to be imported as module with Zon
+    _ = b.addModule("base32", .{
+        .root_source_file = b.path("src/base32.zig"),
+    });
 
     const coverage = b.option(bool, "coverage", "Generate test coverage") orelse false;
 
     var main_tests = b.addTest(
         .{
-            .root_source_file = .{ .path = "src/base32.zig" },
+            .root_source_file = b.path("src/base32.zig"),
             .optimize = optimize,
         },
     );
+
+    const run_main_tests = b.addRunArtifact(main_tests);
 
     if (coverage) {
         main_tests.setExecCmd(&[_]?[]const u8{
@@ -34,5 +45,5 @@ pub fn build(b: *std.build.Builder) void {
     }
 
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.run().step);
+    test_step.dependOn(&run_main_tests.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,35 @@
+.{
+    // This is the default name used by packages depending on this one. For
+    // example, when a user runs `zig fetch --save <url>`, this field is used
+    // as the key in the `dependencies` table. Although the user can choose a
+    // different name, most users will stick with this provided value.
+    //
+    // It is redundant to include "zig" in this name because it is already
+    // within the Zig package namespace.
+    .name = "base32",
+
+    // This is a [Semantic Version](https://semver.org/).
+    // In a future version of Zig it will be used for package deduplication.
+    .version = "0.2.0",
+
+    // This field is optional.
+    // This is currently advisory only; Zig does not yet do anything
+    // with this value.
+    //.minimum_zig_version = "0.11.0",
+
+    // This field is optional.
+    // Each dependency must either provide a `url` and `hash`, or a `path`.
+    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
+    // Once all dependencies are fetched, `zig build` no longer requires
+    // internet connectivity.
+    .dependencies = .{},
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "src",
+        // For example...
+        //"LICENSE",
+        //"README.md",
+    },
+}

--- a/src/base32.zig
+++ b/src/base32.zig
@@ -28,13 +28,13 @@ pub const Encoding = struct {
         return Encoding{
             .buf = blk: {
                 var a: [32]u8 = undefined;
-                std.mem.copy(u8, a[0..], encoder_string);
+                std.mem.copyForwards(u8, a[0..], encoder_string);
                 break :blk a;
             },
             .decode_map = blk: {
                 var a = [_]u8{0xFF} ** 256;
                 for (encoder_string, 0..) |c, i| {
-                    a[@intCast(usize, c)] = @intCast(u8, i);
+                    a[@intCast(c)] = @intCast(i);
                 }
                 break :blk a;
             },
@@ -147,12 +147,12 @@ pub const Encoding = struct {
         if (dest.len < self.decodeLen(source.len)) {
             return error.NotEnoughSpace;
         }
-        var dst = dest;
+        const dst = dest;
         var src = source;
         var end: bool = false;
         var n: usize = 0;
         var dsti: usize = 0;
-        var olen = src.len;
+        const olen = src.len;
         while (src.len > 0 and !end) {
             var dbuf = [_]u8{0} ** 8;
             var dlen: usize = 8;
@@ -340,7 +340,7 @@ test "Decoding" {
     var buf: [1024]u8 = undefined;
     for (pairs) |ts| {
         const size = std_encoding.decodeLen(ts.encoded.len);
-        var result = try std_encoding.decode(buf[0..size], ts.encoded);
+        const result = try std_encoding.decode(buf[0..size], ts.encoded);
         try testing.expectEqualSlices(u8, ts.decoded, result);
     }
 }
@@ -351,7 +351,7 @@ test "Encoding no padding" {
     for (pairs) |ts| {
         const size = std_encoding_no_padding.encodeLen(ts.decoded.len);
         const result = std_encoding_no_padding.encode(buf[0..size], ts.decoded);
-        var expected_end = std.mem.indexOf(u8, ts.encoded, "=") orelse ts.encoded.len;
+        const expected_end = std.mem.indexOf(u8, ts.encoded, "=") orelse ts.encoded.len;
         const expected = ts.encoded[0..expected_end];
         try testing.expectEqualSlices(u8, expected, result);
     }
@@ -362,9 +362,9 @@ test "Decoding no padding" {
     const std_encoding_no_padding = Encoding.initWithPadding(encode_std, null);
     for (pairs) |ts| {
         const size = std_encoding_no_padding.decodeLen(ts.encoded.len);
-        var end_without_padding = std.mem.indexOf(u8, ts.encoded, "=") orelse ts.encoded.len;
+        const end_without_padding = std.mem.indexOf(u8, ts.encoded, "=") orelse ts.encoded.len;
         const encoded_no_pad = ts.encoded[0..end_without_padding];
-        var result = try std_encoding_no_padding.decode(buf[0..size], encoded_no_pad);
+        const result = try std_encoding_no_padding.decode(buf[0..size], encoded_no_pad);
         try testing.expectEqualSlices(u8, ts.decoded, result);
     }
 }


### PR DESCRIPTION
As mentioned in the title:
* this fixes building on Zig 0.13.0
* this adds a `build.zig.zon` file and `b.addModule` to `build.zig`. These changes allow to import `base32` module when fetching the dependency with `zig fetch --save`. Updated the README to include instructions on how to install using the zig package manager, since docs on the package manager are still pretty much non existent at this point. 