### PR TITLE
Fix typo and update example.zig

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,17 +30,17 @@ pub fn main() !void {
 
 fn encodeString() !void {
     const src = "any + old & data";
-    comptime const size = base32.std_encoding.encodeLen(src.len);
+    const size = comptime base32.std_encoding.encodeLen(src.len);
     var buf: [size]u8 = undefined;
-    var out = base32.std_encoding.encode(&buf, src);
+    const out = base32.std_encoding.encode(&buf, src);
     try stdout.print("ExampleEncodingToString:\nsource: \"{s}\"\noutput: {s}\n", .{src, out});
 }
 
 fn decodeString() !void {
     const src = "ONXW2ZJAMRQXIYJAO5UXI2BAAAQGC3TEEDX3XPY=";
-    comptime const size = base32.std_encoding.decodeLen(src.len);
+    const size = comptime base32.std_encoding.decodeLen(src.len);
     var buf: [size]u8 = undefined;
-    var out = try base32.std_encoding.decode(&buf, src);
+    const out = try base32.std_encoding.decode(&buf, src);
     try stdout.print("ExampleDecodingString:\nsource: {s}\noutput: \"{s}\"\n", .{src, out});
 }
 ```

--- a/example.zig
+++ b/example.zig
@@ -10,16 +10,16 @@ pub fn main() !void {
 
 fn encodeString() !void {
     const src = "any + old & data";
-    comptime const size = base32.std_encoding.encodeLen(src.len);
+    const size = comptime base32.std_encoding.encodeLen(src.len);
     var buf: [size]u8 = undefined;
-    var out = base32.std_encoding.encode(&buf, src);
+    const out = base32.std_encoding.encode(&buf, src);
     try stdout.print("ExampleEncodingToString:\nsource: \"{s}\"\noutput: {s}\n", .{ src, out });
 }
 
 fn decodeString() !void {
     const src = "ONXW2ZJAMRQXIYJAO5UXI2BAAAQGC3TEEDX3XPY=";
-    comptime const size = base32.std_encoding.decodeLen(src.len);
+    const size = comptime base32.std_encoding.decodeLen(src.len);
     var buf: [size]u8 = undefined;
-    var out = try base32.std_encoding.decode(&buf, src);
+    const out = try base32.std_encoding.decode(&buf, src);
     try stdout.print("ExampleDecodingString:\nsource: {s}\noutput: \"{s}\"\n", .{ src, out });
 }

--- a/src/base32.zig
+++ b/src/base32.zig
@@ -173,7 +173,7 @@ pub const Encoding = struct {
                     // We've reached the end and there's padding
                     if (src.len + j < 8 - 1) {
                         // not enough padding
-                        log.warn("incorrenct input at {}\n", .{olen});
+                        log.warn("incorrect input at {}\n", .{olen});
                         return error.NotEnoughPadding;
                     }
                     var k: usize = 0;
@@ -181,7 +181,7 @@ pub const Encoding = struct {
                         if (src.len > k and self.pad_char != null and src[k] != self.pad_char.?) {
                             // incorrect padding
                             const pos = olen - src.len + k - 1;
-                            log.warn("incorrenct input at {}\n", .{pos});
+                            log.warn("incorrect input at {}\n", .{pos});
                             return error.IncorrectPadding;
                         }
                     }
@@ -194,7 +194,7 @@ pub const Encoding = struct {
                     // src bytes do not yield enough information to decode a dst byte.
                     if (dlen == 1 or dlen == 3 or dlen == 6) {
                         const pos = olen - src.len - 1;
-                        log.warn("incorrenct input at {}\n", .{pos});
+                        log.warn("incorrect input at {}\n", .{pos});
                         return error.IncorrectPadding;
                     }
                     break;
@@ -206,7 +206,7 @@ pub const Encoding = struct {
                     for (self.decode_map, 0..) |m, idx| {
                         log.warn("== {} ={x}\n", .{ idx, m });
                     }
-                    log.warn("incorrenct input at {}\n", .{pos});
+                    log.warn("incorrect input at {}\n", .{pos});
                     return error.CorruptImput;
                 }
                 j += 1;


### PR DESCRIPTION
I updated example.zig to build on zig 0.13.

And fixed an "incorrenct" typo in base32.zig.