### PR TITLE
Zig 0.15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build and Test
         uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.15.2
       - run: zig build test
   lint:
     runs-on: ubuntu-latest
@@ -28,5 +28,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.9.0
+          version: 0.15.2
       - run: zig fmt --check .

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ exe.root_module.addImport("base32", base32.module("base32"));
 ```zig
 const std = @import("std");
 const base32 = @import("src/base32.zig");
-const stdout = std.io.getStdOut().writer();
+var stdout_writer = std.fs.File.stdout().writer(&.{});
+const stdout = &stdout_writer.interface;
 
 pub fn main() !void {
     try encodeString();

--- a/build.zig
+++ b/build.zig
@@ -4,12 +4,17 @@ pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
 
-    const lib = b.addStaticLibrary(
+    const lib_mod = b.createModule(.{
+        .root_source_file = b.path("src/base32.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    const lib = b.addLibrary(
         .{
+            .linkage = .static,
             .name = "base32",
-            .root_source_file = b.path("src/base32.zig"),
-            .target = target,
-            .optimize = optimize,
+            .root_module = lib_mod,
         },
     );
 
@@ -27,8 +32,7 @@ pub fn build(b: *std.Build) void {
 
     var main_tests = b.addTest(
         .{
-            .root_source_file = b.path("src/base32.zig"),
-            .optimize = optimize,
+            .root_module = lib_mod,
         },
     );
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,11 +6,19 @@
     //
     // It is redundant to include "zig" in this name because it is already
     // within the Zig package namespace.
-    .name = "base32",
+    .name = .base32,
 
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
     .version = "0.2.0",
+
+    // When forking a Zig project, this id should be regenerated (delete the
+    // field and run `zig build`) if the upstream project is still maintained.
+    // Otherwise, the fork is *hostile*, attempting to take control over the
+    // original project's identity. Thus it is recommended to leave the comment
+    // on the following line intact, so that it shows up in code reviews that
+    // modify the field.
+    .fingerprint = 0x5b866306bf9c15ea,
 
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything

--- a/example.zig
+++ b/example.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const base32 = @import("src/base32.zig");
-const stdout = std.io.getStdOut().writer();
+var stdout_writer = std.fs.File.stdout().writer(&.{});
+const stdout = &stdout_writer.interface;
 
 pub fn main() !void {
     try encodeString();


### PR DESCRIPTION
Hi! This updates the base32 library to be compatible with Zig v0.15 (tested on v0.15.2).

However, merging this to master may break things for people using older versions of Zig. I am not sure how you want to handle releases for various Zig versions.